### PR TITLE
Update omniauth dependency to support 1.0 and 2.0

### DIFF
--- a/lib/omniauth/strategies/discourse/sso.rb
+++ b/lib/omniauth/strategies/discourse/sso.rb
@@ -65,7 +65,7 @@ module OmniAuth
           end
 
           def url_encoded_payload
-            URI.escape(base64_encoded_payload)
+            CGI.escape(base64_encoded_payload)
           end
 
           def hex_signature

--- a/omniauth-discourse.gemspec
+++ b/omniauth-discourse.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |gem|
   gem.homepage      = "https://github.com/lackstein/omniauth-discourse"
   gem.license       = "MIT"
 
-  gem.add_dependency "omniauth", "~> 1.0"
+  gem.add_dependency "omniauth", ">= 1.0", "< 3"
   gem.add_development_dependency "bundler", "~> 1.9"
 
   gem.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }


### PR DESCRIPTION
At the moment, I can't install this gem alongside omniauth 2.0 because 2.0's [rails_csrf_protection](https://github.com/cookpad/omniauth-rails_csrf_protection/blob/main/omniauth-rails_csrf_protection.gemspec#L31) requires omniauth be at least 2.0. This PR lets you install this gem alongside omniauth 1.0 or 2.0.

It's worth noting that the official omniauth gems (in the omniauth org), e.g. omniauth-github, have simply changed `"~> 1.0"` to `"~> 2.0"` and bumped the major version of their gem alongside it, but that's presumably because the gem itself required code changes. This one seems to work fine with omniauth 2.0, so I see no reason to bump its major version.